### PR TITLE
[#29] feature: ReactFlow UI 생성

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-router": "^1.130.2",
         "axios": "^1.13.1",
+        "dagre": "^0.8.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "reactflow": "^11.11.4",
@@ -2948,6 +2949,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3405,6 +3416,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -3609,6 +3629,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-router": "^1.130.2",
     "axios": "^1.13.1",
+    "dagre": "^0.8.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "reactflow": "^11.11.4",

--- a/frontend/src/components/BranchDropdown/BranchDropdown.jsx
+++ b/frontend/src/components/BranchDropdown/BranchDropdown.jsx
@@ -1,0 +1,72 @@
+import styled from "styled-components";
+
+export default function BranchDropdown({ label, items, open, setOpen, onSelect }) {
+  return (
+    <Wrap>
+      <Title onClick={() => setOpen(v => !v)}>{label}</Title>
+      {open && (
+        <Menu onMouseLeave={() => setOpen(false)}>
+          {items.map((b) => (
+            <Item
+              key={b.value}
+              $active={b.active}
+              onClick={() => { onSelect(b.value); setOpen(false); }}
+            >
+              {b.value}
+              {b.active && <Check>✓</Check>}
+            </Item>
+          ))}
+        </Menu>
+      )}
+    </Wrap>
+  );
+}
+
+/* === styles === */
+const Wrap = styled.div`
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+`;
+
+const Title = styled.button`
+  all: unset;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: 800;
+  color: #2b3446;
+  padding: 2px 4px;
+  border-radius: 6px;
+  transition: background .15s ease, color .15s ease;
+  &:hover { background: rgba(0,0,0,0.04); }
+`;
+
+const Menu = styled.ul`
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 140px;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: 10px;
+  box-shadow: 0 12px 20px rgba(0,0,0,0.12);
+  overflow: hidden;
+  padding: 4px 0;
+  z-index: 10;
+`;
+
+const Item = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 7px 10px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: ${({ $active }) => ($active ? "#111827" : "#374151")};
+  background: ${({ $active }) => ($active ? "rgba(0,0,0,0.04)" : "transparent")};
+  cursor: pointer;
+  &:hover { background: rgba(0,0,0,0.06); }
+`;
+const Check = styled.span` font-size: 12px; `;

--- a/frontend/src/components/Flow/Edges/DeletableEdge.jsx
+++ b/frontend/src/components/Flow/Edges/DeletableEdge.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { EdgeLabelRenderer, getSmoothStepPath, useReactFlow } from "reactflow";
+import { EdgeDelBtn } from "@/components/flow/styles";
+
+export default function DeletableEdge(props) {
+  const {
+    id,
+    sourceX, sourceY, sourcePosition,
+    targetX, targetY, targetPosition,
+    style,
+    markerEnd,
+    selected,
+  } = props;
+
+  const { setEdges } = useReactFlow();
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX, sourceY, sourcePosition,
+    targetX, targetY, targetPosition,
+  });
+
+  const onDelete = (e) => {
+    e.stopPropagation();
+    setEdges((eds) => eds.filter((e) => e.id !== id));
+  };
+
+  return (
+    <>
+      <path className="react-flow__edge-path" d={edgePath} style={style} markerEnd={markerEnd} />
+      {selected && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: "absolute",
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: "all",
+            }}
+          >
+            <EdgeDelBtn onClick={onDelete} aria-label="엣지 삭제">−</EdgeDelBtn>
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/Flow/FlowCanvas.jsx
+++ b/frontend/src/components/Flow/FlowCanvas.jsx
@@ -1,0 +1,404 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlowProvider,
+  addEdge,
+  useEdgesState,
+  useNodesState,
+  Position,
+} from "reactflow";
+import "reactflow/dist/style.css";
+
+import { GlobalRFStyles, FlowWrap } from "./styles";
+import { nodeStyle, edgeStyle } from "./styles";
+import {
+  edge,
+  stripRuntimeEdge,
+  stripRuntimeNode,
+  serializeEdges,
+  serializeNodes,
+} from "./utils";
+import { initialNodes, initialEdges } from "./initialData";
+import DeletableEdge from "./edges/DeletableEdge";
+import SelectionOverlay from "./overlays/SelectionOverlay";
+
+/* ===== 배치/충돌 관련 상수 & 유틸 ===== */
+const H_SPACING = 260;     // 부모 → 자식 가로 간격
+const V_SPACING = 110;     // 형제 간 세로 간격
+const COLLIDE_EPS = 12;    // 겹침 판단 오차
+const MAX_PER_COL = 5;     // 한 컬럼(세로줄) 당 최대 형제 수
+
+const getChildren = (eds, parentId) =>
+  eds.filter((e) => e.source === parentId).map((e) => e.target);
+
+// 0->0, 1->+1, 2->-1, 3->+2, 4->-2 ...
+const zigzag = (n) => {
+  if (n === 0) return 0;
+  return n % 2 === 1 ? Math.ceil(n / 2) : -n / 2;
+};
+
+// 현재 노드들과 충돌하지 않는 가장 가까운 위치 찾기(아래로 탐색)
+const findFreeSpot = (nodes, startX, startY) => {
+  let x = startX;
+  let y = startY;
+  while (
+    nodes.some(
+      (n) =>
+        Math.abs((n.position?.x ?? 0) - x) < COLLIDE_EPS &&
+        Math.abs((n.position?.y ?? 0) - y) < COLLIDE_EPS
+    )
+  ) {
+    y += V_SPACING;
+  }
+  return { x, y };
+};
+
+/* ===== 루트(들어오는 엣지 없음) 판별 & 핸들 적용 ===== */
+const computeIncomingMap = (edges) => {
+  const map = new Map();
+  edges.forEach((e) => {
+    map.set(e.target, (map.get(e.target) || 0) + 1);
+  });
+  return map;
+};
+
+const withHandlesByRoot = (nodes, edges) => {
+  const incoming = computeIncomingMap(edges);
+  return nodes.map((n) => {
+    const isRoot = !incoming.get(n.id);
+    if (isRoot) {
+      const { targetPosition, ...rest } = n;
+      return {
+        ...rest,
+        sourcePosition: Position.Right, // 루트: 왼쪽 핸들 숨김
+      };
+    }
+    return {
+      ...n,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,   // 비루트: 좌/우 핸들
+    };
+  });
+};
+
+const ROOT_X_OFFSET = 120; // 루트 초기 오프셋(왼쪽으로 이동)
+
+const FlowCanvas = forwardRef(function FlowCanvas(
+  {
+    editMode = true,
+    onCanResetChange,
+    onSelectionCountChange,
+    onNodeClickInViewMode,
+    onCreateNode,
+  },
+  ref
+) {
+  /* ===== 상태 ===== */
+  const [nodes, setNodes, onNodesChange] = useNodesState(
+    withHandlesByRoot(
+      initialNodes.map(stripRuntimeNode).map((n) => ({ ...n, style: nodeStyle })),
+      initialEdges
+    )
+  );
+  const [edges, setEdges, onEdgesChange] = useEdgesState(
+    initialEdges.map(stripRuntimeEdge)
+  );
+
+  const [selectedNodes, setSelectedNodes] = useState([]);
+  const [lastSelectedId, setLastSelectedId] = useState(null);
+
+  // 초기 스냅샷 (리셋/변경감지)
+  const initialSnapshotRef = useRef({
+    nodes: serializeNodes(initialNodes),
+    edges: serializeEdges(initialEdges),
+  });
+
+  /* ===== 연결 ===== */
+  const onConnect = useCallback(
+    (params) => setEdges((eds) => addEdge({ ...params, ...edgeStyle }, eds)),
+    [setEdges]
+  );
+
+  /* ===== 편집 모드 전환 시 선택 해제 ===== */
+  useEffect(() => {
+    if (!editMode) {
+      setSelectedNodes([]);
+      setLastSelectedId(null);
+      onSelectionCountChange?.(0);
+    }
+  }, [editMode, onSelectionCountChange]);
+
+  /* ===== 선택 변경 ===== */
+  const handleSelectionChange = useCallback(
+    ({ nodes: selNodes }) => {
+      if (!editMode) {
+        setSelectedNodes([]);
+        setLastSelectedId(null);
+        onSelectionCountChange?.(0);
+        return;
+      }
+      const list = selNodes || [];
+      setSelectedNodes(list);
+      onSelectionCountChange?.(list.length);
+      if (list.length === 0) setLastSelectedId(null);
+    },
+    [editMode, onSelectionCountChange]
+  );
+
+  /* ===== 노드 클릭 ===== */
+  const onNodeClick = useCallback(
+    (e, node) => {
+      if (!editMode) {
+        e?.preventDefault?.();
+        e?.stopPropagation?.();
+        onNodeClickInViewMode?.();
+        return;
+      }
+      setLastSelectedId(node?.id || null);
+    },
+    [editMode, onNodeClickInViewMode]
+  );
+
+  /* ===== 노드 액션: 자식 추가(지그재그 + 컬럼 래핑 + 충돌회피) ===== */
+  const addSiblingNode = useCallback(() => {
+    if (!lastSelectedId) return;
+    const base = nodes.find((n) => n.id === lastSelectedId);
+    if (!base) return;
+
+    // 현재 부모의 자식 수 = 새 자식의 인덱스
+    const childIds = getChildren(edges, base.id);
+    const idx = childIds.length;           // 0-based
+    const col = Math.floor(idx / MAX_PER_COL);
+    const row = idx % MAX_PER_COL;
+
+    const draftX = (base.position?.x ?? 0) + H_SPACING * (col + 1);
+    const draftY = (base.position?.y ?? 0) + zigzag(row) * V_SPACING;
+
+    const { x, y } = findFreeSpot(nodes, draftX, draftY);
+
+    const newId = `n${Date.now()}`;
+    const newNode = {
+      id: newId,
+      position: { x, y },
+      data: { label: "새 노드" },
+      style: nodeStyle,
+      sourcePosition: Position.Right, // 엣지 업데이트 후 withHandlesByRoot로 좌/우 확정
+    };
+
+    setNodes((nds) => [...nds, newNode]);
+    setEdges((eds) => [...eds, edge(base.id, newId)]);
+    onCreateNode?.(newId);
+  }, [lastSelectedId, nodes, edges, onCreateNode, setNodes, setEdges]);
+
+  const removeSelectedNode = useCallback(() => {
+    if (!lastSelectedId) return;
+
+    setEdges((eds) => {
+      const incoming = eds.filter((e) => e.target === lastSelectedId);
+      const outgoing = eds.filter((e) => e.source === lastSelectedId);
+      const other = eds.filter(
+        (e) => e.source !== lastSelectedId && e.target !== lastSelectedId
+      );
+
+      if (incoming.length === 1) {
+        const parentId = incoming[0].source;
+        const reattached = outgoing
+          .map((e) => ({ s: parentId, t: e.target }))
+          .filter(({ s, t }) => s && t && s !== t)
+          .filter(
+            ({ s, t }) =>
+              !other.some((oe) => oe.source === s && oe.target === t)
+          )
+          .map(({ s, t }) => edge(s, t));
+
+        return [...other, ...reattached];
+      }
+      return other;
+    });
+
+    setNodes((nds) => nds.filter((n) => n.id !== lastSelectedId));
+    setLastSelectedId(null);
+    setSelectedNodes([]);
+    onSelectionCountChange?.(0);
+  }, [lastSelectedId, setEdges, setNodes, onSelectionCountChange]);
+
+  /* ===== 그룹 생성 (콘솔 출력 전용) ===== */
+  const groupSelected = useCallback(() => {
+    const selected = nodes.filter((n) => n.selected);
+    const list = selected.length ? selected : selectedNodes;
+
+    if (list.length < 2) {
+      console.warn("[Group] 최소 2개 이상 선택해야 그룹화가 가능합니다.");
+      return;
+    }
+
+    const fallbackW = 160;
+    const fallbackH = 40;
+    const minX = Math.min(...list.map((n) => n.position.x));
+    const minY = Math.min(...list.map((n) => n.position.y));
+    const maxX = Math.max(
+      ...list.map((n) => n.position.x + (n.width ?? fallbackW))
+    );
+    const maxY = Math.max(
+      ...list.map((n) => n.position.y + (n.height ?? fallbackH))
+    );
+
+    const group = {
+      id: `group-${Date.now()}`,
+      nodeIds: list.map((n) => n.id),
+      count: list.length,
+      bounds: {
+        minX,
+        minY,
+        maxX,
+        maxY,
+        width: maxX - minX,
+        height: maxY - minY,
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    console.log("GROUP_SELECTED", group, list);
+  }, [nodes, selectedNodes]);
+
+  /* ===== 루트 핸들 재적용 & 초기 루트 오프셋 ===== */
+  const didInitialRootOffset = useRef(false);
+
+  // 엣지 변경 시 루트 재판별하여 핸들 갱신
+  useEffect(() => {
+    setNodes((prev) => withHandlesByRoot(prev, edges));
+  }, [edges, setNodes]);
+
+  // 초기 1회: 루트만 살짝 왼쪽으로 이동
+  useEffect(() => {
+    if (didInitialRootOffset.current) return;
+    setNodes((prev) => {
+      const incoming = computeIncomingMap(edges);
+      const roots = prev.filter((n) => !incoming.get(n.id));
+      if (roots.length === 0) return prev;
+
+      return prev.map((n) => {
+        const isRoot = !incoming.get(n.id);
+        if (!isRoot) return n;
+        return {
+          ...n,
+          position: {
+            x: (n.position?.x ?? 0) - ROOT_X_OFFSET,
+            y: n.position?.y ?? 0,
+          },
+        };
+      });
+    });
+    didInitialRootOffset.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /* ===== 리셋 ===== */
+  const reset = useCallback(() => {
+    setNodes(
+      withHandlesByRoot(
+        initialNodes
+          .map(stripRuntimeNode)
+          .map((n) => ({ ...n, style: nodeStyle })),
+        initialEdges
+      )
+    );
+    setEdges(initialEdges.map(stripRuntimeEdge));
+    setLastSelectedId(null);
+    setSelectedNodes([]);
+    onSelectionCountChange?.(0);
+  }, [setNodes, setEdges, onSelectionCountChange]);
+
+  /* ===== 외부에서 호출 가능한 메서드 ===== */
+  const updateNodeLabel = useCallback(
+    (id, label) => {
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, label } } : n
+        )
+      );
+    },
+    [setNodes]
+  );
+
+  useImperativeHandle(ref, () => ({ reset, groupSelected, updateNodeLabel }), [
+    reset,
+    groupSelected,
+    updateNodeLabel,
+  ]);
+
+  /* ===== canReset 계산 & 보고 ===== */
+  useEffect(() => {
+    const now = { nodes: serializeNodes(nodes), edges: serializeEdges(edges) };
+    const base = initialSnapshotRef.current;
+    const changed = now.nodes !== base.nodes || now.edges !== base.edges;
+    onCanResetChange?.(changed);
+  }, [nodes, edges, onCanResetChange]);
+
+  /* ===== 커스텀 엣지 타입 ===== */
+  const edgeTypes = useMemo(() => ({ deletable: DeletableEdge }), []);
+
+  /* ===== 상호작용 옵션 ===== */
+  const rfInteractivity = useMemo(
+    () => ({
+      nodesDraggable: editMode,
+      nodesConnectable: editMode,
+      elementsSelectable: editMode,
+      connectOnClick: editMode,
+      panOnDrag: true,
+      panOnScroll: !editMode,
+      zoomOnScroll: editMode,
+      // snapToGrid: true,
+      // snapGrid: [10, 10],
+    }),
+    [editMode]
+  );
+
+  return (
+    <>
+      <GlobalRFStyles />
+      <ReactFlowProvider>
+        <FlowWrap>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            onSelectionChange={handleSelectionChange}
+            onNodeClick={onNodeClick}
+            fitView
+            proOptions={{ hideAttribution: true }}
+            edgeTypes={edgeTypes}
+            onPaneContextMenu={(e) => e.preventDefault()}
+            {...rfInteractivity}
+          >
+            <Background gap={18} size={1} />
+            <MiniMap pannable />
+            <Controls />
+            {editMode && (
+              <SelectionOverlay
+                selectedNodes={selectedNodes}
+                lastSelectedId={lastSelectedId}
+                onAdd={addSiblingNode}
+                onRemove={removeSelectedNode}
+              />
+            )}
+          </ReactFlow>
+        </FlowWrap>
+      </ReactFlowProvider>
+    </>
+  );
+});
+
+export default FlowCanvas;

--- a/frontend/src/components/Flow/Overlays/SelectionOverlay.jsx
+++ b/frontend/src/components/Flow/Overlays/SelectionOverlay.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { useStore } from "reactflow";
+import { AbsoluteBox, IconBtn } from "@/components/flow/styles";
+
+export default function SelectionOverlay({ selectedNodes, lastSelectedId, onAdd, onRemove }) {
+  if (!selectedNodes || selectedNodes.length === 0) return null;
+
+  const [tx, ty, zoom] = useStore((s) => s.transform);
+  const targetId = lastSelectedId ?? selectedNodes?.[0]?.id ?? null;
+  const internalNode = useStore((s) => (targetId ? s.nodeInternals.get(targetId) : undefined));
+  if (!internalNode) return null;
+
+  const z = Math.max(0.7, Math.min(1.6, zoom));
+  const BTN_W = 36 * z;
+  const BTN_H = 28 * z;
+  const GAP_X = 8 * z;
+  const GAP_Y = 6 * z;
+  const RADIUS = 14 * z;
+  const FONT = 18 * z;
+
+  const x = (internalNode.positionAbsolute?.x ?? internalNode.position.x) * zoom + tx;
+  const y = (internalNode.positionAbsolute?.y ?? internalNode.position.y) * zoom + ty;
+  const w = (internalNode.width ?? 0) * zoom;
+
+  const TOTAL_W = BTN_W * 2 + GAP_X;
+
+  const posStyle = {
+    left: Math.round(x + w / 2 - TOTAL_W / 2),
+    top: Math.round(y - (BTN_H + GAP_Y)),
+    gap: GAP_X,
+  };
+
+  return (
+    <AbsoluteBox style={posStyle}>
+      <IconBtn
+        aria-label="노드 추가"
+        style={{ minWidth: BTN_W, height: BTN_H, borderRadius: RADIUS, fontSize: FONT }}
+        onClick={onAdd}
+      >
+        +
+      </IconBtn>
+      <IconBtn
+        $danger
+        aria-label="노드 삭제"
+        style={{ minWidth: BTN_W, height: BTN_H, borderRadius: RADIUS, fontSize: FONT }}
+        onClick={onRemove}
+      >
+        −
+      </IconBtn>
+    </AbsoluteBox>
+  );
+}

--- a/frontend/src/components/Flow/initialData.js
+++ b/frontend/src/components/Flow/initialData.js
@@ -1,0 +1,47 @@
+import { nodeStyle } from "./styles";
+
+// (선택) 방향 상수: "LR" or "TB"
+export const LAYOUT = "LR";
+const isHorizontal = LAYOUT === "LR";
+
+const SOURCE_POS = isHorizontal ? "right" : "bottom";
+const TARGET_POS = isHorizontal ? "left"  : "top";
+
+export const initialNodes = [
+  {
+    id: "n1",
+    position: { x: 120, y: 140 },
+    data: { label: "다익스트라 개념" },
+    style: nodeStyle,
+    sourcePosition: SOURCE_POS,
+    // 루트는 FlowCanvas에서 target 숨김 처리됨(좌측 점 X)
+    targetPosition: TARGET_POS,
+  },
+  {
+    id: "n2",
+    position: { x: 420, y: 140 },
+    data: { label: "우선순위큐" },
+    style: nodeStyle,
+    sourcePosition: SOURCE_POS,
+    targetPosition: TARGET_POS,
+  },
+  {
+    id: "n3",
+    position: { x: 420, y: 300 },
+    data: { label: "시간복잡도 O(E log V)" },
+    style: nodeStyle,
+    sourcePosition: SOURCE_POS,
+    targetPosition: TARGET_POS,
+  },
+  {
+    id: "n4",
+    position: { x: 120, y: 300 },
+    data: { label: "BFS/DFS 비교" },
+    style: nodeStyle,
+    sourcePosition: SOURCE_POS,
+    targetPosition: TARGET_POS,
+  },
+];
+
+import { edge } from "./utils";
+export const initialEdges = [edge("n1", "n2"), edge("n2", "n3"), edge("n1", "n4")];

--- a/frontend/src/components/Flow/layout.js
+++ b/frontend/src/components/Flow/layout.js
@@ -1,0 +1,51 @@
+// /src/components/flow/layout.js
+import dagre from "dagre";
+
+// 기본 노드 크기(측정 전) — styled width/height 없을 때 사용
+const DEFAULT_NODE_WIDTH = 160;
+const DEFAULT_NODE_HEIGHT = 40;
+
+export function getLayoutedElements(nodes, edges, direction = "LR") {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({
+    rankdir: direction,   // "LR" 좌→우, "TB" 상→하
+    nodesep: 60,          // 노드 간 간격
+    ranksep: 120,         // 레벨 간 간격
+    marginx: 20,
+    marginy: 20,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  // 그래프에 노드/엣지 주입
+  nodes.forEach((n) => {
+    const width =
+      n.width ??
+      n.measured?.width ??
+      n.style?.width ??
+      DEFAULT_NODE_WIDTH;
+    const height =
+      n.height ??
+      n.measured?.height ??
+      n.style?.height ??
+      DEFAULT_NODE_HEIGHT;
+    g.setNode(n.id, { width, height });
+  });
+
+  edges.forEach((e) => g.setEdge(e.source, e.target));
+
+  dagre.layout(g);
+
+  // dagre 결과를 React Flow 포맷의 position에 반영
+  const laidOutNodes = nodes.map((n) => {
+    const { x, y } = g.node(n.id) || { x: n.position.x, y: n.position.y };
+    return {
+      ...n,
+      // Dagre는 중심 좌표를 주므로 좌상단 기준으로 보정
+      position: { x: x - (n.width ?? DEFAULT_NODE_WIDTH) / 2, y: y - (n.height ?? DEFAULT_NODE_HEIGHT) / 2 },
+      // 위치는 우리가 고정(드래그 가능은 editMode로 제어)
+      // (필요시 'sourcePosition'/'targetPosition'도 'right'/'left'로 줄 수 있음)
+    };
+  });
+
+  return { nodes: laidOutNodes, edges };
+}

--- a/frontend/src/components/Flow/styles.js
+++ b/frontend/src/components/Flow/styles.js
@@ -1,0 +1,97 @@
+// /src/components/flow/styles.js
+import styled, { createGlobalStyle } from "styled-components";
+import { MarkerType } from "reactflow";
+
+/* ===== Global styles for selected node highlight ===== */
+export const GlobalRFStyles = createGlobalStyle`
+  .react-flow__node.selected {
+    border: 2px solid #48b17a !important;
+    box-shadow:
+      0 0 0 3px rgba(72, 177, 122, .15),
+      0 6px 12px rgba(0, 0, 0, .06) !important;
+  }
+`;
+
+/* ===== Canvas Wrapper ===== */
+export const FlowWrap = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+`;
+
+/* ===== Node / Edge base styles ===== */
+export const nodeStyle = {
+  background: "#fff",
+  border: "1px solid rgba(0,0,0,.08)",
+  borderRadius: 10,
+  padding: "8px 10px",
+  fontSize: 12,
+  boxShadow: "0 6px 12px rgba(0,0,0,.06)",
+};
+
+export const edgeStyle = {
+  type: "deletable",
+  animated: false,
+  markerEnd: { type: MarkerType.ArrowClosed, color: "#406992", width: 24, height: 24 },
+  style: { stroke: "#406992", strokeWidth: 2 },
+  interactionWidth: 24,
+};
+
+/**
+ * ✅ 그룹 노드 스타일 생성 함수
+ * (필요한 곳에서 import해서 사용)
+ */
+export const makeGroupNodeStyle = ({
+  bg = "#F4FAF7",
+  border = "#BFEAD0",
+  dashed = true,
+} = {}) => ({
+  ...nodeStyle,
+  background: bg,
+  border: `2px ${dashed ? "dashed" : "solid"} ${border}`,
+  borderRadius: 14,
+  padding: "12px 14px",
+});
+
+/* ===== Overlay Buttons ===== */
+export const AbsoluteBox = styled.div`
+  position: absolute;
+  z-index: 5;
+  pointer-events: auto;
+  display: flex;
+`;
+
+export const IconBtn = styled.button`
+  min-width: 36px;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 14px;
+  border: 1px solid ${({ $danger }) => ($danger ? "#f1c9c9" : "#cfe9da")};
+  background: ${({ $danger }) => ($danger ? "#f6e9e9" : "#edf9f3")};
+  color: ${({ $danger }) => ($danger ? "#b74e4e" : "#2d9364")};
+  font-size: 18px;
+  line-height: 1;
+  font-weight: 900;
+  box-shadow: 0 6px 14px rgba(0,0,0,.06);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const EdgeDelBtn = styled.button`
+  width: 28px;
+  height: 28px;
+  border-radius: 14px;
+  border: 1px solid #f1c9c9;
+  background: #f6e9e9;
+  color: #b74e4e;
+  font-size: 18px;
+  line-height: 1;
+  font-weight: 900;
+  box-shadow: 0 6px 14px rgba(0,0,0,.06);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/components/Flow/utils.js
+++ b/frontend/src/components/Flow/utils.js
@@ -1,0 +1,40 @@
+import { edgeStyle } from "./styles";
+
+export function edge(source, target) {
+  return { id: `${source}-${target}`, source, target, ...edgeStyle };
+}
+
+export function stripRuntimeNode(n) {
+  return {
+    id: n.id,
+    position: { x: n.position.x, y: n.position.y },
+    data: { label: n.data?.label ?? "" },
+    style: undefined, // 라우트에서 nodeStyle 주입됨(초기화 시)
+    sourcePosition: n.sourcePosition, // ⬅️ 추가
+    targetPosition: n.targetPosition, // ⬅️ 추가
+  };
+}
+
+export function stripRuntimeEdge(e) {
+  return { id: e.id, source: e.source, target: e.target, ...edgeStyle };
+}
+
+export function serializeNodes(ns) {
+  return JSON.stringify(
+    ns.map((n) => ({
+      id: n.id,
+      x: n.position.x,
+      y: n.position.y,
+      label: n.data?.label ?? "",
+    }))
+  );
+}
+
+export function serializeEdges(es) {
+  return JSON.stringify(
+    es.map((e) => ({
+      s: e.source,
+      t: e.target,
+    }))
+  );
+}

--- a/frontend/src/components/switch/SwitchButton.jsx
+++ b/frontend/src/components/switch/SwitchButton.jsx
@@ -1,0 +1,59 @@
+import styled from "styled-components";
+
+export default function SwitchButton({ on, onToggle, title }) {
+  return (
+    <Switch
+      role="switch"
+      aria-checked={on}
+      $on={on}
+      onClick={onToggle}
+      title={title}
+    >
+      <SwitchLabelOn  $on={on}>ON</SwitchLabelOn>
+      <SwitchLabelOff $on={on}>OFF</SwitchLabelOff>
+      <Knob $on={on} />
+    </Switch>
+  );
+}
+
+/* === styles === */
+const Switch = styled.button`
+  all: unset;
+  position: relative;
+  width: 56px;
+  height: 28px;
+  border-radius: 9999px;
+  background: ${({ $on }) => ($on ? "#4b6182" : "#c6c8cc")};
+  border: 2px solid ${({ $on }) => ($on ? "#4b6182" : "#c6c8cc")};
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,.05), 0 3px 8px rgba(0,0,0,.08);
+  cursor: pointer;
+  transition: background .18s ease, border-color .18s ease;
+`;
+
+const Knob = styled.span`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: ${({ $on }) => ($on ? "calc(100% - 22px - 4px)" : "4px")};
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 3px 7px rgba(0,0,0,.18);
+  transition: left .2s cubic-bezier(.22,.61,.36,1);
+`;
+
+const LabelBase = styled.span`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: .3px;
+  color: #fff;
+  font-size: 11px;
+  user-select: none;
+  pointer-events: none;
+  transition: opacity .15s ease;
+`;
+const SwitchLabelOn = styled(LabelBase)` left: 9px;  opacity: ${({ $on }) => ($on ? 1 : 0)}; `;
+const SwitchLabelOff = styled(LabelBase)` right: 8px; opacity: ${({ $on }) => ($on ? 0 : 1)}; `;

--- a/frontend/src/components/topleftCard/TopleftCard.jsx
+++ b/frontend/src/components/topleftCard/TopleftCard.jsx
@@ -1,0 +1,74 @@
+import styled from "styled-components";
+import SwitchButton from "@/components/switch/SwitchButton";
+
+export default function TopleftCard({
+  editMode,
+  setEditMode,
+  onSave,
+  onInit,
+  canReset = false,   // ✅ 추가: 초기화 가능 여부
+}) {
+  return (
+    <Card>
+      <PillRow>
+        <PillBtn onClick={onSave}>저장</PillBtn>
+        <PillBtn $ghost disabled={!canReset} onClick={canReset ? onInit : undefined}>
+          초기화
+        </PillBtn>
+      </PillRow>
+
+      <SwitchRow>
+        <SwitchText>편집 모드</SwitchText>
+        <SwitchButton
+          on={editMode}
+          onToggle={() => setEditMode((v) => !v)}
+          title={editMode ? "편집 모드 ON" : "편집 모드 OFF"}
+        />
+      </SwitchRow>
+    </Card>
+  );
+}
+
+/* === styles === */
+const Card = styled.div`
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 4;
+  width: 248px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #f1f4f8;
+  border: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 8px 14px rgba(0,0,0,0.10);
+  display: grid;
+  gap: 8px;
+`;
+const PillRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+`;
+const PillBtn = styled.button`
+  height: 34px;
+  border: 0;
+  border-radius: 14px;
+  font-weight: 800;
+  font-size: 12.5px;
+  color: #fff;
+  background: ${({ $ghost }) => ($ghost ? "#e9eaec" : "#5a6f8e")};
+  opacity: ${({ disabled }) => (disabled ? 0.6 : 1)};
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
+  transition: filter .15s ease;
+  &:hover { filter: ${({ disabled }) => (disabled ? "none" : "brightness(1.06)")}; }
+`;
+const SwitchRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+const SwitchText = styled.span`
+  font-size: 13px;
+  font-weight: 700;
+  color: #2b374b;
+`;

--- a/frontend/src/routes/__root.jsx
+++ b/frontend/src/routes/__root.jsx
@@ -1,13 +1,90 @@
+// /src/routes/__root.jsx
 import { createRootRoute, Outlet } from '@tanstack/react-router'
+import styled from 'styled-components'
+import Sidebar from '@/components/layout/Sidebar'
+import { useSidebarStore } from '@/store/useSidebarStore'
+import { useEffect, useMemo, useRef } from 'react'
+
+const TRANS_MS = 280; // 사이드바/메인 전환 시간(ms)
 
 export const Route = createRootRoute({
   component: RootLayout,
 })
 
 function RootLayout() {
+  const { isCollapsed } = useSidebarStore()
+  const sidebarW = useMemo(() => (isCollapsed ? 72 : 260), [isCollapsed])
+
+  const mainRef = useRef(null)
+
+  // 전환 종료 시점에 resize 이벤트를 날려 ReactFlow가 최종 레이아웃에서 리사이즈하도록
+  useEffect(() => {
+    const el = mainRef.current
+    if (!el) return
+
+    const onEnd = (e) => {
+      if (e.propertyName === 'margin-left') {
+        // 메인 margin-left 전환이 끝났을 때만
+        window.dispatchEvent(new Event('resize'))
+      }
+    }
+    el.addEventListener('transitionend', onEnd)
+    return () => el.removeEventListener('transitionend', onEnd)
+  }, [])
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
-      <Outlet />
-    </div>
+    <Shell>
+      {/* 고정 사이드바(너비에 트랜지션) */}
+      <AsideWrap
+        $w={sidebarW}
+        style={{ '--sbw': `${sidebarW}px` }}
+      >
+        <Sidebar />
+      </AsideWrap>
+
+      {/* 메인(왼쪽 마진에 트랜지션) */}
+      <Main
+        ref={mainRef}
+        $left={sidebarW}
+        style={{ '--left': `${sidebarW}px` }}
+      >
+        <Outlet />
+      </Main>
+    </Shell>
   )
 }
+
+/* ===== styled ===== */
+const Shell = styled.div`
+  position: relative;
+  min-height: 100dvh;
+  background: #f5f7fb;
+  font-family: 'Pretendard', 'Noto Sans KR', sans-serif;
+`
+
+const AsideWrap = styled.aside`
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+
+  /* width 전환을 부드럽게 */
+  width: var(--sbw, 260px);
+  transition: width ${TRANS_MS}ms ease;
+
+  z-index: 5; /* 메인(1)보다 위, 모달보다 아래여도 OK */
+  background: transparent; /* 실제 배경은 Sidebar 내부에서 처리 */
+  will-change: width;
+`
+
+const Main = styled.main`
+  position: relative;
+  min-height: 100dvh;
+
+  /* margin-left 전환을 부드럽게 */
+  margin-left: var(--left, 260px);
+  transition: margin-left ${TRANS_MS}ms ease;
+
+  /* 부드러운 전환 힌트 */
+  will-change: margin-left;
+`

--- a/frontend/src/routes/test.jsx
+++ b/frontend/src/routes/test.jsx
@@ -1,54 +1,152 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import styled from "styled-components";
-import ModalShell from "@/components/ModalShell/ModalShell";
-import { useChatList } from "@/hooks/useChatList";
 
-export const Route = createFileRoute("/test")({
-  component: RouteComponent,
-});
+import { useChatList } from "@/hooks/useChatList";
+import BranchDropdown from "@/components/BranchDropdown/BranchDropdown";
+import TopleftCard from "@/components/topleftCard/TopleftCard";
+import ModalShell from "@/components/ModalShell/ModalShell";
+import FlowCanvas from "@/components/flow/FlowCanvas";
+
+export const Route = createFileRoute("/test")({ component: RouteComponent });
 
 function RouteComponent() {
-  const [open, setOpen] = useState(false);
-  const [type, setType] = useState("chat"); // 'chat' | 'search' | 'layers'
-
+  /* ===== 채팅 데이터 ===== */
   const { messages, addUser, addAssistant } = useChatList([
     { id: "u1", role: "user", content: "다익스트라 알고리즘 예시 말해줘", ts: Date.now() - 2000 },
     { id: "a1", role: "assistant", content: "다익스트라 알고리즘의 예시입니다.", ts: Date.now() - 1000 },
   ]);
-
   const [input, setInput] = useState("");
 
-  const handleSend = () => {
+  // ➕ 방금 만든(혹은 편집 중인) 노드 id
+  const [editingNodeId, setEditingNodeId] = useState(null);
+
+  const handleSend = useCallback(() => {
     const t = input.trim();
     if (!t) return;
+
+    // 채팅 히스토리
     addUser(t);
     setInput("");
-    setTimeout(() => addAssistant("응답: " + t), 500);
+    setTimeout(() => addAssistant("응답: " + t), 300);
+
+    // ✏️ 편집 타겟 노드 라벨 갱신
+    if (editingNodeId) {
+      canvasRef.current?.updateNodeLabel(editingNodeId, t);
+      // 필요 시 편집 해제하려면 다음 줄 주석 해제
+      // setEditingNodeId(null);
+    }
+  }, [input, addUser, addAssistant, editingNodeId]);
+
+  /* ===== 상단 컨트롤 ===== */
+  const [branchOpen, setBranchOpen] = useState(false);
+  const [branch, setBranch] = useState("브랜치-2");
+  const branches = ["브랜치-1", "브랜치-2", "브랜치-3"];
+
+  /* ===== 상태 ===== */
+  const [editMode, setEditMode] = useState(true);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [panelType, setPanelType] = useState("chat");
+
+  const canvasRef = useRef(null);
+  const [canReset, setCanReset] = useState(false);
+  const [selectedCount, setSelectedCount] = useState(0);
+
+  const handleInit = () => canvasRef.current?.reset();
+
+  const openChatPanel = () => {
+    setPanelType("chat");
+    setPanelOpen(true);
   };
+
+  // FlowCanvas가 새 노드를 만들었다고 알려줄 때: 모달 열고, 편집 타겟 지정
+  const handleCreateNode = useCallback((newNodeId) => {
+    setEditingNodeId(newNodeId);
+    setPanelType("chat");
+    setPanelOpen(true);
+  }, []);
+
+  // 편집 모드 + 2개 이상 선택 시만 그룹 버튼
+  const showGroupButton = editMode && selectedCount > 1;
 
   return (
     <Page>
+      <TopleftCard
+        editMode={editMode}
+        setEditMode={setEditMode}
+        onSave={() => console.log("저장!")}
+        onInit={handleInit}
+        canReset={canReset}
+      />
+
+      <BranchDropdown
+        label={branch}
+        items={branches.map((v) => ({ value: v, active: v === branch }))}
+        open={branchOpen}
+        setOpen={setBranchOpen}
+        onSelect={setBranch}
+      />
+
+      {/* ✅ 그룹 생성 버튼 */}
+      {showGroupButton && (
+        <TopCenterActionBar>
+          <GroupChip onClick={() => canvasRef.current?.groupSelected()}>
+            ＋ 그룹 생성
+          </GroupChip>
+        </TopCenterActionBar>
+      )}
+
       <ModalShell
-        open={open}
-        onOpen={() => setOpen(true)}
-        onClose={() => setOpen(false)}
-        type={type}
-        setType={setType}
-        title="브랜치-2"
+        open={panelOpen}
+        onOpen={() => setPanelOpen(true)}
+        onClose={() => setPanelOpen(false)}
+        type={panelType}
+        setType={setPanelType}
+        title={branch}
         messages={messages}
         input={input}
         onInputChange={setInput}
         onSend={handleSend}
         peek={false}
       />
+
+      <FlowCanvas
+        ref={canvasRef}
+        editMode={editMode}
+        onCanResetChange={setCanReset}
+        onSelectionCountChange={setSelectedCount}
+        onNodeClickInViewMode={openChatPanel}
+        onCreateNode={handleCreateNode}   // ⬅️ 새 노드 생성 시 모달 열고 편집 대상 지정
+      />
     </Page>
   );
 }
 
+/* ===== styled ===== */
 const Page = styled.div`
   position: relative;
   min-height: 100dvh;
-  background-color: #fafafa;
-  font-family: "Pretendard", "Noto Sans KR", sans-serif;
 `;
+
+const TopCenterActionBar = styled.div`
+  position: absolute;
+  top: 48px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+`;
+
+const GroupChip = styled.button`
+  height: 30px;
+  padding: 0 14px;
+  border: 1px solid #bfead0;
+  background: #e9f7f0;
+  color: #2d9364;
+  border-radius: 9999px;
+  font-size: 13px;
+  font-weight: 800;
+  box-shadow: 0 6px 14px rgba(0,0,0,.06);
+  cursor: pointer;
+`;
+
+export default Route;


### PR DESCRIPTION
## ❗️ 관련 이슈
- Close #29 

## 🚀 작업 내용
- 노드 생성(노드가 새 채팅일지 / 노드일지 / 그룹일지
- 노드 삭제(노드 삭제할 때 자식 노드들을 삭제된 부모 노드에 연결하기)
- 엣지 생성
- 엣지 삭제
- 초기화
- 편집 모드 ON(채팅방이 열리지 않고 ReactFlow 편집이 가능함)
- 편집 모드 OFF(채팅방이 열림)
- 브랜치 드롭다운
- 그룹 생성

## 🤔 고민했던 점

## 💬 리뷰 포인트
