### PR TITLE
[#141] fix: 그룹 스냅샷 생성 시 status가 복사되지 않아 500 반환하는 문제

### DIFF
--- a/core-api/src/main/java/io/ssafy/p/k13c103/coreapi/domain/chat/entity/Chat.java
+++ b/core-api/src/main/java/io/ssafy/p/k13c103/coreapi/domain/chat/entity/Chat.java
@@ -121,6 +121,7 @@ public class Chat extends BaseTimeEntity {
                 .summary(group.getSummary())
                 .keywords(group.getKeywords())
                 .chatType(ChatType.CHAT)
+                .status(ChatStatus.SUMMARY_KEYWORDS)
                 .build();
     }
 


### PR DESCRIPTION
## ❗️ 관련 이슈
- Close #141

## 🚀 작업 내용
- `Chat.java` 엔티티 내 `createGroupSnapshot()`에서 status를 복사하지 않아 NOT NULL 컬럼에 null 값이 들어가 500 발생. status를 추가로 복사해줌으로써 해결.