### PR TITLE
[#171] fix(chat): fallback summary가 DB에 반영되지 않는 문제 수정

### DIFF
--- a/core-api/src/main/java/io/ssafy/p/k13c103/coreapi/domain/chat/service/ChatServiceImpl.java
+++ b/core-api/src/main/java/io/ssafy/p/k13c103/coreapi/domain/chat/service/ChatServiceImpl.java
@@ -31,7 +31,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -332,7 +331,7 @@ public class ChatServiceImpl implements ChatService {
                                             summary = buildFallbackSummary(keywords, aiAnswer);
                                         }
 
-                                        chat.updateSummaryAndKeywords(aiResult.getSummary(), convertToJson(aiResult.getKeywords()));
+                                        chat.updateSummaryAndKeywords(summary, convertToJson(keywords));
                                         chatRepository.save(chat);
 
                                         Map<String, Object> payload = new LinkedHashMap<>();


### PR DESCRIPTION
### 📌 작업 내용 및 변경 사항
- 긴 요약 + 키워드 처리 단계(STEP 3)에서 fallback summary가 생성되었을 경우 
  DB 저장 시 해당 fallback을 사용하도록 수정
- 기존에는 aiResult.getSummary()를 그대로 저장하여 빈 문자열이 DB에 들어가는 문제였음
- SSE 페이로드 값과 DB 저장 값이 일치하도록 개선

### 🤔 고민한 점
- fallback summary를 무조건 DB에 저장해도 되는지 정책 검토
- 원본 summary(빈 문자열)도 따로 보관해야 할 필요는 없는지 논의 필요

### 🥺 리뷰해줬으면 하는 부분
- updateSummaryAndKeywords(summary, keywords) 적용 위치 적절성
- 예외처리 또는 log 위치 개선 필요 여부