### PR TITLE
[#174] fix: 키워드 검색 시 빈 배열이 반환되는 문제 해결

### DIFF
--- a/core-api/src/main/java/io/ssafy/p/k13c103/coreapi/domain/chat/repository/ChatRepository.java
+++ b/core-api/src/main/java/io/ssafy/p/k13c103/coreapi/domain/chat/repository/ChatRepository.java
@@ -28,7 +28,7 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
         FROM chat c
         JOIN room r ON r.room_uid = c.room_id
         WHERE r.owner_id = :memberId
-          AND c.group_id = null
+          AND c.group_id IS NULL
           AND c.status   = 'SUMMARY_KEYWORDS'
           AND c.is_chat  = 'CHAT'
           AND NOT EXISTS (
@@ -44,7 +44,7 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
           FROM chat c
           JOIN room r ON r.room_uid = c.room_id
           WHERE r.owner_id = :memberId
-            AND c.group_id = null
+            AND c.group_id IS NULL
             AND c.status   = 'SUMMARY_KEYWORDS'
             AND c.is_chat  = 'CHAT'
             AND NOT EXISTS (
@@ -81,7 +81,7 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
         FROM chat c
         WHERE c.status  = 'SUMMARY_KEYWORDS'
           AND c.is_chat = 'CHAT'
-          AND c.group_id = null
+          AND c.group_id IS NULL
           AND EXISTS (
               SELECT 1
               FROM room r
@@ -95,7 +95,7 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
         FROM chat c
         WHERE c.status  = 'SUMMARY_KEYWORDS'
           AND c.is_chat = 'CHAT'
-          AND c.group_id = null
+          AND c.group_id IS NULL
           AND EXISTS (
               SELECT 1
               FROM room r


### PR DESCRIPTION
## ❗️ 관련 이슈
- Close #174

## 🚀 작업 내용
- 키워드 검색 시 빈 배열이 반환되는 문제 해결 (`= null` -> `IS NULL`)
